### PR TITLE
Feat: Added the storage to store when the modal is displayed

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from dependency_injector.wiring import Provide, inject
+from models.display import Display
 import uvicorn
 from sqlalchemy.exc import ArgumentError
 from pydbantic import Database
@@ -58,7 +59,7 @@ async def init_db(
 ):
     try:
         db = await Database.create(
-            config["survey_db"], tables=[Project, Comment, ProjectEncryption]
+            config["survey_db"], tables=[Project, Comment, ProjectEncryption, Display]
         )
         logging.info("Database ready")
     except ArgumentError as e:

--- a/models/display.py
+++ b/models/display.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import validator
+from models.project import Project
+from pydbantic import DataBaseModel, PrimaryKey, ForeignKey
+
+class Display(DataBaseModel):
+    """
+    Comment model for the SQL table
+    """
+
+    id: Optional[int] = PrimaryKey(autoincrement=True)
+    project_id: int = ForeignKey(Project, "id")
+    user_id: str
+    timestamp: str
+    feature_url: str
+
+    @validator("timestamp")
+    def encode_timestamp(cls, value):
+        try:
+            datetime.fromisoformat(value)
+        except ValueError:
+            raise ValueError("Invalid timestamp format")
+        return value

--- a/repository/sqlite_repository.py
+++ b/repository/sqlite_repository.py
@@ -3,6 +3,7 @@ from typing import List, Union
 import logging
 
 from models.comment import Comment, CommentPostBody
+from models.display import Display
 from models.project import Project, ProjectEncryption
 from utils.encryption import Encryption
 
@@ -92,3 +93,30 @@ class SQLiteRepository:
             return encryptions[0]
         else:
             return None
+        
+    async def create_display(
+            self, project_name: str, user_id: int, timestamp: str, feature_url: str
+    ) -> Union[Display, None]:
+        
+        projects = await Project.filter(name=project_name)
+
+        if len(projects) == 0:
+            logging.warning("Project missing on display creation")
+
+            # ajouter une partie qui permet de gérer la clé
+            project = await self.create_project(Project(name=project_name))
+        else:
+            project = projects[0]
+
+        new_display = Display(
+            project_id = project.id,
+            user_id = user_id,
+            timestamp = timestamp,
+            feature_url = feature_url
+        )
+
+        id = await new_display.insert()
+        new_display.id = id
+        logging.debug(f"Display created in DB: {new_display}")
+        return new_display
+        

--- a/routes/rules.py
+++ b/routes/rules.py
@@ -44,7 +44,8 @@ async def show_modal(
     # Set user_id Cookie if is None
     if user_id is None:
         logging.info("GET rules::Setting a new user_id cookie")
-        response.set_cookie(key="user_id", value=str(uuid4()))
+        user_id = str(uuid4())
+        response.set_cookie(key="user_id", value=user_id)
 
     # Get current timestamp
     dateToday: datetime = datetime.now()
@@ -79,5 +80,9 @@ async def show_modal(
         encrypted_timestamp = encryption.encrypt(timestamp_bytes)
         # Add the encrypted timestamp as cookie to the response
         response.set_cookie(key="timestamp", value=encrypted_timestamp)
-
+        # Store the timestamp when it's displayed
+        iso_timestamp = dateToday.isoformat()
+        await sqlite_repo.create_display(
+            project_name, user_id, iso_timestamp, featureUrl
+        )
     return isDisplay

--- a/tests/test_sqlite_repository.py
+++ b/tests/test_sqlite_repository.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from unittest.mock import AsyncMock
 
 from models.comment import Comment, CommentPostBody
+from models.display import Display
 from models.project import Project, ProjectEncryption
 from repository.sqlite_repository import SQLiteRepository
 
@@ -93,3 +94,31 @@ class TestSQLiteRepository(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, db_project)
         Project.insert.assert_not_called()
         ProjectEncryption.insert.assert_not_called()
+
+    async def test_create_display(self):
+        user_id = 123
+        timestamp = "03/24/23 12:00:00"
+        timestamp_dt = datetime.strptime(timestamp, "%m/%d/%y %H:%M:%S").isoformat()
+        self.repository.create_project = AsyncMock(
+            return_value=Project(id=1, name="test_project")
+        )
+        Display.insert = AsyncMock(return_value=5)
+        Project.filter = AsyncMock(return_value=[Project(id=1, name="test_project")])
+        result = await self.repository.create_display(
+            feature_url=self.comment_body.feature_url,
+            user_id=user_id,
+            timestamp=timestamp_dt,
+            project_name=self.project_name,
+        )
+
+        Display.insert.assert_called_once()
+        self.assertEqual(
+            result,
+            Display(
+                id=5,
+                project_id=1,
+                feature_url=self.comment_body.feature_url,
+                user_id=user_id,
+                timestamp=timestamp_dt
+            ),
+        )


### PR DESCRIPTION
# Store the number when the modal is displayed to the user.

A new table called 'Display' has been added with the fields 'id', 'project_id', 'feature_url', and 'timestamp'. 
The 'create_display' method has also been added to the 'SQLRepository' class. 
Finally, the storage on display has been added to the 'show_modal' route.